### PR TITLE
Fixed bug where importing MTGO would fail sometimes

### DIFF
--- a/src/services/scryfall.tsx
+++ b/src/services/scryfall.tsx
@@ -201,7 +201,7 @@ export async function fetchVariants(title: string): Promise<Partial<Card>[]> {
         totalVariants: arr.length,
       };
 
-      if (card["type_line"].toLowerCase().includes("token")) {
+      if (card["type_line"]?.toLowerCase().includes("token")) {
         const manaTypes = (card["colors"] ?? card["color_identity"]).flatMap(
           manaLetterToType
         );


### PR DESCRIPTION
Apparently, not all cards have a "type_line", when searching the Scryfall API.

Which means the `if (card["type_line"].toLowerCase().includes("token")) {` condition would fail with a `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`


### Steps to reproduce:
1. Click the "import from MTGO button
2. Type in `1 Command Tower`
3. Click "Submit"
4. Check browser console

See: https://api.scryfall.com/cards/search/?q=!%22Command%20Tower%22%20unique:art%20prefer:newest
And search for Card ID `bffbe9ec-edbc-43ed-a3bf-60635e7e625c`


This PR changes it so we also return false if `card["type_line"]` is undefined.